### PR TITLE
Decouple CLI Presentation (ProgressBar) from Core Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ var engine = EngineBuilder.Create().WithConfiguration(config).Build();
 // Setup download
 var pauseTokenSource = new PauseTokenSource();
 using var cancelTokenSource = new CancellationTokenSource();
-using var progressReporter = new ConsoleProgressReporter(config);
+using var progressReporter = new ConsoleProgressReporter(config.ShowProgress);
         
 // Download the file
 engine.DownloadFile(new OctaneRequest(url, null), pauseTokenSource, cancelTokenSource.Token, progressReporter).Wait();  

--- a/README.md
+++ b/README.md
@@ -31,24 +31,27 @@ dotnet add package OctaneEngineCore
 ```csharp
 const string url = "https://plugins.jetbrains.com/files/7973/281233/sonarlint-intellij-7.4.0.60471.zip?updateId=281233&pluginId=7973&family=INTELLIJ";
 
+var config = new OctaneConfiguration {
+        Parts = 8,
+        BufferSize = 8192,
+        ShowProgress = true,
+        NumRetries = 10,
+        BytesPerSecond = 1,
+        UseProxy = false,
+        LowMemoryMode = false,
+        RetryCap = 30
+};
+
 // Create engine directly without builder - no DI required (if you don't want it!)
-var engine = EngineBuilder.Create().WithConfiguration(config => {
-        config.Parts = 8;
-        config.BufferSize = 8192;
-        config.ShowProgress = true;
-        config.NumRetries = 10;
-        config.BytesPerSecond = 1;
-        config.UseProxy = false;
-        config.LowMemoryMode = false;
-        config.RetryCap = 30;
-}).Build();
+var engine = EngineBuilder.Create().WithConfiguration(config).Build();
         
 // Setup download
 var pauseTokenSource = new PauseTokenSource();
 using var cancelTokenSource = new CancellationTokenSource();
+using var progressReporter = new ConsoleProgressReporter(config);
         
 // Download the file
-engine.DownloadFile(new OctaneRequest(url, null), pauseTokenSource, cancelTokenSource.Token).Wait();  
+engine.DownloadFile(new OctaneRequest(url, null), pauseTokenSource, cancelTokenSource.Token, progressReporter).Wait();  
 ```
 ## If you want to use Dependency Injection
 ### Program.cs
@@ -74,11 +77,12 @@ await Host.CreateDefaultBuilder(args).UseSerilog((context, configuration) =>
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using OctaneEngineCore;
 
 namespace OctaneTester;
 
-public class DownloadService(IEngine engine, IHostApplicationLifetime lifetime, ILogger<DownloadService> logger) : BackgroundService
+public class DownloadService(IEngine engine, IOptions<OctaneConfiguration> config, IHostApplicationLifetime lifetime, ILogger<DownloadService> logger) : BackgroundService
 {
     private const string Url = "https://plugins.jetbrains.com/files/7973/281233/sonarlint-intellij-7.4.0.60471.zip?updateId=281233&pluginId=7973&family=INTELLIJ";
 
@@ -87,7 +91,10 @@ public class DownloadService(IEngine engine, IHostApplicationLifetime lifetime, 
         var pauseTokenSource = new PauseTokenSource();
         logger.LogInformation("Current Latency: {latency}", await engine.GetCurrentNetworkLatency());
         logger.LogInformation("Current Network speed: {speed}", await engine.GetCurrentNetworkSpeed());
-        await engine.DownloadFile(new OctaneRequest(Url, null), pauseTokenSource, stoppingToken);
+        
+        using var progressReporter = new ConsoleProgressReporter(config.Value);
+        await engine.DownloadFile(new OctaneRequest(Url, null), pauseTokenSource, stoppingToken, progressReporter);
+        
         lifetime.StopApplication();
     }
 }

--- a/examples/OctaneTester/DownloadService.cs
+++ b/examples/OctaneTester/DownloadService.cs
@@ -19,7 +19,7 @@ public class DownloadService(IEngine engine, IOptions<OctaneConfiguration> confi
         logger.LogInformation("Current Latency: {latency}", await engine.GetCurrentNetworkLatency());
         logger.LogInformation("Current Network speed: {speed}", await engine.GetCurrentNetworkSpeed());
         
-        using var progressReporter = new ConsoleProgressReporter(config.Value);
+        using var progressReporter = new ConsoleProgressReporter(config.Value.ShowProgress);
         await engine.DownloadFile(new OctaneRequest(Url, "test1.zip"), pauseTokenSource, stoppingToken, progressReporter);
         
         lifetime.StopApplication();

--- a/examples/OctaneTester/DownloadService.cs
+++ b/examples/OctaneTester/DownloadService.cs
@@ -2,13 +2,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OctaneEngineCore;
 using OctaneEngineCore.Clients;
 using OctaneEngineCore.Interfaces;
 
 namespace OctaneTester;
 
-public class DownloadService(IEngine engine, IHostApplicationLifetime lifetime, ILogger<DownloadService> logger) : BackgroundService
+public class DownloadService(IEngine engine, IOptions<OctaneConfiguration> config, IHostApplicationLifetime lifetime, ILogger<DownloadService> logger) : BackgroundService
 {
     private const string Url = "https://plugins.jetbrains.com/files/7973/281233/sonarlint-intellij-7.4.0.60471.zip?updateId=281233&pluginId=7973&family=INTELLIJ";
 
@@ -17,7 +18,10 @@ public class DownloadService(IEngine engine, IHostApplicationLifetime lifetime, 
         var pauseTokenSource = new PauseTokenSource();
         logger.LogInformation("Current Latency: {latency}", await engine.GetCurrentNetworkLatency());
         logger.LogInformation("Current Network speed: {speed}", await engine.GetCurrentNetworkSpeed());
-        await engine.DownloadFile(new OctaneRequest(Url, "test1.zip"), pauseTokenSource, stoppingToken);
+        
+        using var progressReporter = new ConsoleProgressReporter(config.Value);
+        await engine.DownloadFile(new OctaneRequest(Url, "test1.zip"), pauseTokenSource, stoppingToken, progressReporter);
+        
         lifetime.StopApplication();
     }
 }

--- a/examples/OctaneTester/Program.cs
+++ b/examples/OctaneTester/Program.cs
@@ -20,7 +20,7 @@ namespace OctaneTester
             {
                 configuration
                     .Enrich.FromLogContext()
-                    .MinimumLevel.Verbose()
+                    .MinimumLevel.Error()
                     .WriteTo.Async(a => a.Console(theme: AnsiConsoleTheme.Sixteen));
             }).ConfigureAppConfiguration(configurationBuilder =>
             {

--- a/examples/OctaneTester/appsettings.json
+++ b/examples/OctaneTester/appsettings.json
@@ -2,7 +2,7 @@
   "Octane": {
     "Parts": 8,
     "BufferSize": 32768,
-    "ShowProgress": false,
+    "ShowProgress": true,
     "NumRetries": 10,
     "RetryCap": 30,
     "BytesPerSecond": 1,

--- a/src/OctaneEngine/Clients/DefaultClient.cs
+++ b/src/OctaneEngine/Clients/DefaultClient.cs
@@ -30,7 +30,6 @@ using System.IO.Pipelines;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using OctaneEngineCore.ShellProgressBar;
 using OctaneEngineCore;
 
 namespace OctaneEngineCore.Clients;
@@ -38,7 +37,6 @@ namespace OctaneEngineCore.Clients;
 public class DefaultClient : IClient
 {
     private MemoryMappedFile _mmf;
-    private ProgressBar _pBar;
     private readonly HttpClient _httpClient;
     private readonly OctaneConfiguration _config;
     private readonly PipeOptions _pipeOptions;
@@ -68,11 +66,6 @@ public class DefaultClient : IClient
         _mmf = file;
     }
 
-    public void SetProgressbar(ProgressBar bar)
-    {
-        _pBar = bar;
-    }
-    
     private async Task CopyMessageContentToStreamWithProgressAsync(
         HttpResponseMessage message, 
         Stream stream, 
@@ -136,7 +129,7 @@ public class DefaultClient : IClient
         }
     }
     
-    public async Task Download(string url, (long, long) piece, Dictionary<string, string> headers, CancellationToken cancellationToken, PauseToken pauseToken)
+    public async Task Download(string url, (long start, long end) piece, int partIndex, long totalBytes, Dictionary<string, string>? headers, IProgress<DownloadProgress>? progress, CancellationToken cancellationToken, PauseToken pauseToken)
     {
         if (pauseToken.IsPaused)
         {
@@ -161,25 +154,32 @@ public class DefaultClient : IClient
         }
 
         long totalWritten = 0;
+        long pieceLength = totalBytes;
         
-        var progress = new System.Progress<long>(bytesWritten =>
+        var progressReporter = new System.Progress<long>(bytesWritten =>
         {
-            totalWritten += bytesWritten;
+            totalWritten = bytesWritten;
 
-            // Only update progress bar if ShowProgress is enabled
-            if (_config.ShowProgress && totalWritten % ((piece.Item2-piece.Item1) / _config.BufferSize) == 0)
+            progress?.Report(new DownloadProgress
             {
-                _pBar?.Tick();
-            }
+                TotalBytes = totalBytes,
+                BytesDownloaded = totalWritten,
+                ProgressPercentage = totalBytes > 0 ? (double)totalWritten / totalBytes * 100.0 : 0.0,
+                TotalParts = 1,
+                PartsCompleted = totalWritten >= pieceLength ? 1 : 0,
+                PartIndex = partIndex,
+                PartBytesDownloaded = totalWritten,
+                PartTotalBytes = pieceLength,
+                PartCompleted = totalWritten >= pieceLength
+            });
         });
         using var stream = _mmf.CreateViewStream();
-        await CopyMessageContentToStreamWithProgressAsync(message, stream, progress);
+        await CopyMessageContentToStreamWithProgressAsync(message, stream, progressReporter);
     }
 
     public void Dispose()
     {
         _httpClient?.Dispose();
         _mmf?.Dispose();
-        _pBar?.Dispose();
     }
 }

--- a/src/OctaneEngine/Clients/IClient.cs
+++ b/src/OctaneEngine/Clients/IClient.cs
@@ -27,7 +27,6 @@ using System.Collections.Generic;
 using System.IO.MemoryMappedFiles;
 using System.Threading;
 using System.Threading.Tasks;
-using OctaneEngineCore.ShellProgressBar;
 
 namespace OctaneEngineCore.Clients;
 
@@ -35,6 +34,5 @@ public interface IClient
 {
     public bool IsRangeSupported();
     public void SetMmf(MemoryMappedFile file);
-    public void SetProgressbar(ProgressBar bar);
-    internal Task Download(string url, (long start, long end) piece, Dictionary<string, string> headers, CancellationToken cancellationToken, PauseToken pauseToken);
+    internal Task Download(string url, (long start, long end) piece, int partIndex, long totalBytes, Dictionary<string, string>? headers, IProgress<DownloadProgress>? progress, CancellationToken cancellationToken, PauseToken pauseToken);
 }

--- a/src/OctaneEngine/Clients/OctaneClient.cs
+++ b/src/OctaneEngine/Clients/OctaneClient.cs
@@ -35,7 +35,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OctaneEngineCore.Implementations.NetworkAnalyzer;
-using OctaneEngineCore.ShellProgressBar;
 using OctaneEngineCore.Streams;
 
 namespace OctaneEngineCore.Clients;
@@ -48,21 +47,10 @@ public partial class OctaneClient : IClient
     private readonly ILoggerFactory _loggerFactory;
     private ArrayPool<byte> _memPool = ArrayPool<byte>.Shared;
     private MemoryMappedFile? _mmf;
-    private ProgressBar? _progressBar;
     private readonly PipeOptions _pipeOptions;
     private readonly long _tickStep;
-
-    private static readonly ProgressBarOptions ChildProgressBarOptions = new()
-    {
-        CollapseWhenFinished = true,
-        DisplayTimeInRealTime = false,
-        BackgroundColor = ConsoleColor.Magenta,
-        DenseProgressBar = true,
-        DisableBottomPercentage = true,
-        ShowEstimatedDuration = true
-    };
     
-    public OctaneClient(OctaneConfiguration config, HttpClient httpClient, ILoggerFactory loggerFactory, ProgressBar? progressBar = null)
+    public OctaneClient(OctaneConfiguration config, HttpClient httpClient, ILoggerFactory loggerFactory)
     {
         _config = config;
         _pipeOptions = new PipeOptions(
@@ -76,7 +64,6 @@ public partial class OctaneClient : IClient
         );
         _client = httpClient;
         _loggerFactory = loggerFactory;
-        _progressBar = progressBar;
         _log = loggerFactory.CreateLogger<IClient>();
         _tickStep = Math.Max(_config.BufferSize * 2L, 1 * 1024 * 1024L);
     }
@@ -84,7 +71,6 @@ public partial class OctaneClient : IClient
     public bool IsRangeSupported() => true;
 
     public void SetMmf(MemoryMappedFile file) => _mmf = file;
-    public void SetProgressbar(ProgressBar bar) => _progressBar = bar;
     private async ValueTask<HttpResponseMessage> SendRangeRequestAsync(
         Uri uri, 
         (long start, long end) piece, 
@@ -119,7 +105,7 @@ public partial class OctaneClient : IClient
         return response;
     }
     
-    public async Task Download(string url,(long start, long end) piece, Dictionary<string, string>? headers, CancellationToken cancellationToken, PauseToken pauseToken)
+    public async Task Download(string url, (long start, long end) piece, int partIndex, long totalBytes, Dictionary<string, string>? headers, IProgress<DownloadProgress>? progress, CancellationToken cancellationToken, PauseToken pauseToken)
     {
         LogSendingRequestForRangePieces(piece.start, piece.end);
         var stopwatch = new Stopwatch();
@@ -149,11 +135,6 @@ public partial class OctaneClient : IClient
                 throttleStream.SetBps(programBps);
             }
 
-            // Only create child progress bar if ShowProgress is enabled, and we have a progress bar
-            using var child = (_config.ShowProgress && _progressBar != null) 
-                ? _progressBar.Spawn(piece.end - piece.start, "Downloading part...", ChildProgressBarOptions)
-                : null;
-
             if (_mmf is null)
             {
                 throw new InvalidOperationException("MMF not initialized before download.");
@@ -161,11 +142,11 @@ public partial class OctaneClient : IClient
             
             if (_config.LowMemoryMode)
             {
-                await LowMemoryDownload(piece, cancellationToken, wrappedStream, child);
+                await LowMemoryDownload(piece, partIndex, totalBytes, progress, cancellationToken, wrappedStream);
             }
             else
             {
-                await RegularDownload(piece, cancellationToken, wrappedStream, child);
+                await RegularDownload(piece, partIndex, totalBytes, progress, cancellationToken, wrappedStream);
             }
         }
         else
@@ -173,16 +154,11 @@ public partial class OctaneClient : IClient
             LogHttpRequestReturnedSuccessStatusCodeCode((int)message.StatusCode, NetworkAnalyzer.PrettySize(piece.start), NetworkAnalyzer.PrettySize(piece.end));
         }
         
-        // Only tick the progress bar if ShowProgress is enabled
-        if (_config.ShowProgress)
-        {
-            _progressBar?.Tick();
-        }
         stopwatch.Stop();
         LogPieceExecutionTimeElapsedMilliseconds(NetworkAnalyzer.PrettySize(piece.start), NetworkAnalyzer.PrettySize(piece.end), stopwatch.ElapsedMilliseconds);
     }
 
-    private async Task RegularDownload((long start, long end) piece, CancellationToken cancellationToken, Stream wrappedStream, ChildProgressBar? child)
+    private async Task RegularDownload((long start, long end) piece, int partIndex, long totalBytes, IProgress<DownloadProgress>? progress, CancellationToken cancellationToken, Stream wrappedStream)
     {
         int readBufferSize = Math.Max(_config.BufferSize, 256 * 1024);
         var readBuffer = _memPool.Rent(readBufferSize);
@@ -194,6 +170,7 @@ public partial class OctaneClient : IClient
         }
 
         var stream = _mmf.CreateViewStream(piece.start, piece.end - piece.start + 1);
+        long partTotalBytes = piece.end - piece.start + 1;
                 
         try
         {
@@ -211,9 +188,16 @@ public partial class OctaneClient : IClient
                 await stream.WriteAsync(readBuffer.AsMemory(0, bytesRead), cancellationToken);
                 bytesReadOverall += bytesRead;
                         
-                if(child != null && (bytesReadOverall - lastProgressUpdate >= progressUpdateInterval))
+                if(progress != null && (bytesReadOverall - lastProgressUpdate >= progressUpdateInterval || bytesReadOverall == partTotalBytes))
                 {
-                    child.Tick(bytesReadOverall);
+                    progress.Report(new DownloadProgress
+                    {
+                        TotalBytes = totalBytes,
+                        PartIndex = partIndex,
+                        PartBytesDownloaded = bytesReadOverall,
+                        PartTotalBytes = partTotalBytes,
+                        PartCompleted = bytesReadOverall >= partTotalBytes
+                    });
                     lastProgressUpdate = bytesReadOverall;
                 }
             }
@@ -227,7 +211,7 @@ public partial class OctaneClient : IClient
         }
     }
 
-    private async Task LowMemoryDownload((long start, long end) piece, CancellationToken cancellationToken, Stream wrappedStream, ChildProgressBar? child)
+    private async Task LowMemoryDownload((long start, long end) piece, int partIndex, long totalBytes, IProgress<DownloadProgress>? progress, CancellationToken cancellationToken, Stream wrappedStream)
     {
         if (_config.BytesPerSecond > 1)
         {
@@ -253,7 +237,7 @@ public partial class OctaneClient : IClient
             {
                 var pipe = new Pipe(_pipeOptions);
                 var writing = FillPipeAsync(wrappedStream, pipe.Writer, cancellationToken);
-                var reading = ReadPipeToFileAsync(pipe.Reader, piece, child, accessorPtr, cancellationToken);
+                var reading = ReadPipeToFileAsync(pipe.Reader, piece, partIndex, totalBytes, progress, accessorPtr, cancellationToken);
                 await Task.WhenAll(reading, writing);
             }
             catch (Exception ex)
@@ -299,10 +283,11 @@ public partial class OctaneClient : IClient
         }
     }
     
-    private async Task ReadPipeToFileAsync(PipeReader reader, (long start, long end) piece, ChildProgressBar? child, IntPtr accessorPtr, CancellationToken token)
+    private async Task ReadPipeToFileAsync(PipeReader reader, (long start, long end) piece, int partIndex, long totalBytes, IProgress<DownloadProgress>? progress, IntPtr accessorPtr, CancellationToken token)
     {
         long accessorLength = piece.end - piece.start + 1;
         long writeOffset = 0;
+        long partTotalBytes = accessorLength;
 
         try
         {
@@ -329,7 +314,14 @@ public partial class OctaneClient : IClient
                     
                     if (writeOffset - lastTick >= _tickStep || writeOffset == accessorLength)
                     {
-                        child?.Tick((int)Math.Min(writeOffset, int.MaxValue));
+                        progress?.Report(new DownloadProgress
+                        {
+                            TotalBytes = totalBytes,
+                            PartIndex = partIndex,
+                            PartBytesDownloaded = writeOffset,
+                            PartTotalBytes = partTotalBytes,
+                            PartCompleted = writeOffset == accessorLength
+                        });
                         lastTick = writeOffset;
                     }
                 }
@@ -359,7 +351,14 @@ public partial class OctaneClient : IClient
 
                         if (writeOffset - lastTick >= _tickStep || writeOffset == accessorLength)
                         {
-                            child?.Tick((int)writeOffset);
+                            progress?.Report(new DownloadProgress
+                            {
+                                TotalBytes = totalBytes,
+                                PartIndex = partIndex,
+                                PartBytesDownloaded = writeOffset,
+                                PartTotalBytes = partTotalBytes,
+                                PartCompleted = writeOffset == accessorLength
+                            });
                             lastTick = writeOffset;
                         }
 

--- a/src/OctaneEngine/ConsoleProgressReporter.cs
+++ b/src/OctaneEngine/ConsoleProgressReporter.cs
@@ -5,13 +5,14 @@ namespace OctaneEngineCore;
 
 public class ConsoleProgressReporter : IProgress<DownloadProgress>, IDisposable
 {
-    private readonly OctaneConfiguration _config;
     private ProgressBar? _mainProgressBar;
     private readonly ConcurrentDictionary<int, ChildProgressBar> _childBars = new();
     private readonly object _lock = new();
     private bool _isDisposed;
 
-    private static readonly ProgressBarOptions MainProgressBarOptions = new()
+    public bool ShowProgress { get; set; } = true;
+
+    public ProgressBarOptions MainProgressBarOptions { get; set; } = new()
     {
         ProgressBarOnBottom = false,
         BackgroundCharacter = '\u2593',
@@ -19,7 +20,7 @@ public class ConsoleProgressReporter : IProgress<DownloadProgress>, IDisposable
         DisplayTimeInRealTime = false
     };
 
-    private static readonly ProgressBarOptions ChildProgressBarOptions = new()
+    public ProgressBarOptions ChildProgressBarOptions { get; set; } = new()
     {
         CollapseWhenFinished = true,
         DisplayTimeInRealTime = false,
@@ -29,14 +30,25 @@ public class ConsoleProgressReporter : IProgress<DownloadProgress>, IDisposable
         ShowEstimatedDuration = true
     };
 
-    public ConsoleProgressReporter(OctaneConfiguration config)
+    public ConsoleProgressReporter()
     {
-        _config = config;
+    }
+
+    public ConsoleProgressReporter(bool showProgress)
+    {
+        ShowProgress = showProgress;
+    }
+
+    public ConsoleProgressReporter(bool showProgress, ProgressBarOptions mainOptions, ProgressBarOptions childOptions)
+    {
+        ShowProgress = showProgress;
+        MainProgressBarOptions = mainOptions ?? MainProgressBarOptions;
+        ChildProgressBarOptions = childOptions ?? ChildProgressBarOptions;
     }
 
     public void Report(DownloadProgress value)
     {
-        if (!_config.ShowProgress)
+        if (!ShowProgress)
         {
             return;
         }

--- a/src/OctaneEngine/ConsoleProgressReporter.cs
+++ b/src/OctaneEngine/ConsoleProgressReporter.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Concurrent;
+using OctaneEngineCore.ShellProgressBar;
+namespace OctaneEngineCore;
+
+public class ConsoleProgressReporter : IProgress<DownloadProgress>, IDisposable
+{
+    private readonly OctaneConfiguration _config;
+    private ProgressBar? _mainProgressBar;
+    private readonly ConcurrentDictionary<int, ChildProgressBar> _childBars = new();
+    private readonly object _lock = new();
+    private bool _isDisposed;
+
+    private static readonly ProgressBarOptions MainProgressBarOptions = new()
+    {
+        ProgressBarOnBottom = false,
+        BackgroundCharacter = '\u2593',
+        DenseProgressBar = false,
+        DisplayTimeInRealTime = false
+    };
+
+    private static readonly ProgressBarOptions ChildProgressBarOptions = new()
+    {
+        CollapseWhenFinished = true,
+        DisplayTimeInRealTime = false,
+        BackgroundColor = ConsoleColor.Magenta,
+        DenseProgressBar = true,
+        DisableBottomPercentage = true,
+        ShowEstimatedDuration = true
+    };
+
+    public ConsoleProgressReporter(OctaneConfiguration config)
+    {
+        _config = config;
+    }
+
+    public void Report(DownloadProgress value)
+    {
+        if (!_config.ShowProgress)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            if (_isDisposed) return;
+
+            // Initialize the main progress bar on the first update
+            if (_mainProgressBar == null)
+            {
+                // We tick the main progress bar once when a part completes
+                _mainProgressBar = new ProgressBar(value.TotalParts, "Downloading file...", MainProgressBarOptions);
+            }
+
+            // For DefaultClient or single-part downloads, just update the main progress bar
+            if (value.TotalParts <= 1)
+            {
+                var percentage = (int)Math.Round(value.ProgressPercentage);
+                _mainProgressBar.Tick(percentage);
+                return;
+            }
+
+            // For multi-part parallel downloads, manage child progress bars
+            var child = _childBars.GetOrAdd(value.PartIndex, index => 
+                _mainProgressBar.Spawn(value.PartTotalBytes, $"Downloading part {index + 1}...", ChildProgressBarOptions));
+
+            if (value.PartCompleted)
+            {
+                child.Tick(value.PartTotalBytes);
+                child.Dispose();
+                _mainProgressBar.Tick($"Completed part {value.PartIndex + 1}");
+            }
+            else
+            {
+                child.Tick(value.PartBytesDownloaded);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            if (_isDisposed) return;
+            _isDisposed = true;
+
+            foreach (var child in _childBars.Values)
+            {
+                child.Dispose();
+            }
+            _childBars.Clear();
+
+            _mainProgressBar?.Dispose();
+            _mainProgressBar = null;
+        }
+    }
+}

--- a/src/OctaneEngine/DownloadProgress.cs
+++ b/src/OctaneEngine/DownloadProgress.cs
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Greg James
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#nullable enable
+
+namespace OctaneEngineCore;
+
+/// <summary>
+/// Represents the progress of a file download operation.
+/// </summary>
+public class DownloadProgress
+{
+    /// <summary>
+    /// The total size of the file in bytes.
+    /// </summary>
+    public long TotalBytes { get; init; }
+
+    /// <summary>
+    /// The overall number of bytes downloaded so far.
+    /// </summary>
+    public long BytesDownloaded { get; init; }
+
+    /// <summary>
+    /// The overall progress percentage (from 0 to 100).
+    /// </summary>
+    public double ProgressPercentage { get; init; }
+
+    /// <summary>
+    /// The total number of download parts/threads.
+    /// </summary>
+    public int TotalParts { get; init; }
+
+    /// <summary>
+    /// The number of completed parts/threads.
+    /// </summary>
+    public int PartsCompleted { get; init; }
+
+    /// <summary>
+    /// The index of the part that triggered this progress update.
+    /// </summary>
+    public int PartIndex { get; init; }
+
+    /// <summary>
+    /// The number of bytes downloaded in the specific part that triggered this update.
+    /// </summary>
+    public long PartBytesDownloaded { get; init; }
+
+    /// <summary>
+    /// The total number of bytes in the specific part that triggered this update.
+    /// </summary>
+    public long PartTotalBytes { get; init; }
+
+    /// <summary>
+    /// Whether the specific part has finished downloading.
+    /// </summary>
+    public bool PartCompleted { get; init; }
+}

--- a/src/OctaneEngine/EngineBuilder.cs
+++ b/src/OctaneEngine/EngineBuilder.cs
@@ -56,7 +56,6 @@ public class EngineBuilder
         return this;
     }
 
-
     /// <summary>
     /// Sets the preconfigured HTTP Client to use (optional)
     /// </summary>

--- a/src/OctaneEngine/EngineBuilder.cs
+++ b/src/OctaneEngine/EngineBuilder.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Options;
 using OctaneEngineCore.Implementations;
 using OctaneEngineCore.Clients;
 using OctaneEngineCore.Interfaces;
-using OctaneEngineCore.ShellProgressBar;
 
 namespace OctaneEngineCore;
 
@@ -18,7 +17,6 @@ public class EngineBuilder
 {
     private OctaneConfiguration _configuration;
     private ILoggerFactory _loggerFactory;
-    private ProgressBar _progressBar;
     private HttpClient _client;
     private IHttpClientFactory _clientFactory;
 
@@ -58,15 +56,7 @@ public class EngineBuilder
         return this;
     }
 
-    /// <summary>
-    /// Sets the progress bar (optional)
-    /// </summary>
-    public EngineBuilder WithProgressBar(ProgressBar progressBar)
-    {
-        _progressBar = progressBar;
-        return this;
-    }
-    
+
     /// <summary>
     /// Sets the preconfigured HTTP Client to use (optional)
     /// </summary>
@@ -111,7 +101,7 @@ public class EngineBuilder
             _clientFactory = new SingleHttpClientFactory(_client);
         }
         
-        var octaneClient = new OctaneClient(_configuration, clientToUse, _loggerFactory, _progressBar);
+        var octaneClient = new OctaneClient(_configuration, clientToUse, _loggerFactory);
         var defaultClient = new DefaultClient(clientToUse, _configuration);
 
         // Create engine

--- a/src/OctaneEngine/Implementations/Engine.cs
+++ b/src/OctaneEngine/Implementations/Engine.cs
@@ -28,6 +28,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.IO.MemoryMappedFiles;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.ExceptionServices;
@@ -39,7 +40,6 @@ using Microsoft.Extensions.Options;
 using OctaneEngineCore.Clients;
 using OctaneEngineCore.Implementations.NetworkAnalyzer;
 using OctaneEngineCore.Interfaces;
-using OctaneEngineCore.ShellProgressBar;
 // ReSharper disable All
 
 namespace OctaneEngineCore.Implementations;
@@ -94,7 +94,7 @@ public partial class Engine: IEngine, IDisposable
             _config.BytesPerSecond = 1;
 
         _clientFactory = new SingleHttpClientFactory(httpClient);
-        _client = new OctaneClient(_config, httpClient, _factory, null);
+        _client = new OctaneClient(_config, httpClient, _factory);
         _defaultClient = new DefaultClient(httpClient, _config);
     }
         
@@ -192,7 +192,7 @@ public partial class Engine: IEngine, IDisposable
     /// <param name="request">The OctaneRequest Object for the request.</param>
     /// <param name="pauseTokenSource">The pause token source to use for pausing and resuming.</param>
     /// <param name="token">The cancellation token to use for the download.</param>
-    public async Task DownloadFile(OctaneRequest request, PauseTokenSource? pauseTokenSource = null, CancellationToken token = default)
+    public async Task DownloadFile(OctaneRequest request, PauseTokenSource? pauseTokenSource = null, CancellationToken token = default, IProgress<DownloadProgress>? progress = null)
     {
         var stopwatch = new Stopwatch();
         var success = false;
@@ -241,24 +241,60 @@ public partial class Engine: IEngine, IDisposable
                         CancellationToken = cancellation_token,
                         //TaskScheduler = TaskScheduler.Current
                     };
-                    ProgressBar? pbar = null;
                     
-                    if (_config.ShowProgress)
+                    long totalBytes = length;
+                    int totalParts = pieces.Count;
+                    long[] partBytes = new long[totalParts];
+                    bool[] partCompleted = new bool[totalParts];
+                    int partsCompleted = 0;
+                    var progressLock = new object();
+
+                    var internalProgress = new Progress<DownloadProgress>(p =>
                     {
-                        pbar = new ProgressBar(pieces.Count * 2, "Downloading file...");
-                        octaneClient.SetProgressbar(pbar);
-                        defaultClient.SetProgressbar(pbar);
-                    }
+                        lock (progressLock)
+                        {
+                            partBytes[p.PartIndex] = p.PartBytesDownloaded;
+                            if (p.PartCompleted && !partCompleted[p.PartIndex])
+                            {
+                                partCompleted[p.PartIndex] = true;
+                                partsCompleted++;
+                            }
+                            
+                            long overallDownloaded = 0;
+                            for (int i = 0; i < totalParts; i++)
+                            {
+                                overallDownloaded += partBytes[i];
+                            }
+                            
+                            double percentage = totalBytes > 0 ? (double)overallDownloaded / totalBytes * 100.0 : 0.0;
+                            
+                            var report = new DownloadProgress
+                            {
+                                TotalBytes = totalBytes,
+                                BytesDownloaded = overallDownloaded,
+                                ProgressPercentage = percentage,
+                                TotalParts = totalParts,
+                                PartsCompleted = partsCompleted,
+                                PartIndex = p.PartIndex,
+                                PartBytesDownloaded = p.PartBytesDownloaded,
+                                PartTotalBytes = p.PartTotalBytes,
+                                PartCompleted = p.PartCompleted
+                            };
+
+                            progress?.Report(report);
+                        }
+                    });
 
                     try
                     {
-                        await pieces.ForEachAsync(options, async (piece, token) =>
+                        var piecesWithIndex = pieces.Select((piece, index) => (piece, index)).ToList();
+                        await piecesWithIndex.ForEachAsync(options, async (item, token) =>
                         {
-                            await octaneClient.Download(request.Url, piece, request.Headers ?? [], cancellation_token, pause_token.Token);
+                            var (piece, index) = item;
+                            await octaneClient.Download(request.Url, piece, index, totalBytes, request.Headers ?? [], internalProgress, cancellation_token, pause_token.Token);
 
                             Interlocked.Increment(ref tasksDone);
                                 
-                            pbar?.Tick();
                             _config?.ProgressCallback?.Invoke((double)tasksDone / _config.Parts);
                         }).ConfigureAwait(false);
                             
@@ -279,9 +315,15 @@ public partial class Engine: IEngine, IDisposable
                 {
                     LogUsingDefaultClientToDownloadFile();
                     defaultClient.SetMmf(mmf);
+                    long totalBytes = length;
+                    var internalProgress = new Progress<DownloadProgress>(p =>
+                    {
+                        progress?.Report(p);
+                    });
+
                     try
                     {
-                        await defaultClient.Download(request.Url, (0, 0), request.Headers ?? [], cancellation_token, pause_token.Token).ConfigureAwait(false);
+                        await defaultClient.Download(request.Url, (0, 0), 0, totalBytes, request.Headers ?? [], internalProgress, cancellation_token, pause_token.Token).ConfigureAwait(false);
                         success = true;
                     }
                     catch (Exception)

--- a/src/OctaneEngine/Interfaces/IEngine.cs
+++ b/src/OctaneEngine/Interfaces/IEngine.cs
@@ -8,7 +8,7 @@ namespace OctaneEngineCore.Interfaces;
 
 public interface IEngine
 {
-    public Task DownloadFile(OctaneRequest request, PauseTokenSource pauseTokenSource = null, CancellationToken token = default);
+    public Task DownloadFile(OctaneRequest request, PauseTokenSource pauseTokenSource = null, CancellationToken token = default, IProgress<DownloadProgress>? progress = null);
     public void SetProgressCallback(Action<double> callback);
     public void SetDoneCallback(Action<bool> callback);
     public void SetProxy(IWebProxy proxy);

--- a/src/OctaneEngine/ServiceCollectionExtensions.cs
+++ b/src/OctaneEngine/ServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Options;
 using OctaneEngineCore.Clients;
 using OctaneEngineCore.Implementations;
 using OctaneEngineCore.Interfaces;
-using OctaneEngineCore.ShellProgressBar;
 
 namespace OctaneEngineCore;
 
@@ -20,7 +19,6 @@ public static class ServiceCollectionExtensions
         hostBuilder.ConfigureServices((context, services) =>
         {
             services.Configure<OctaneConfiguration>(context.Configuration.GetSection("Octane"));
-            services.AddProgressBar();
             services.AddClient();
             services.AddTransient<IEngine, Engine>();
         });
@@ -36,7 +34,6 @@ public static class ServiceCollectionExtensions
         hostBuilder.ConfigureServices((context, services) =>
         {
             services.Configure<OctaneConfiguration>(configure);
-            services.AddProgressBar();
             services.AddClient();
             services.AddTransient<IEngine, Engine>();
         });
@@ -49,7 +46,6 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddOctaneEngine(this IServiceCollection services)
     {
-        services.AddProgressBar();
         services.AddClient();
         services.AddTransient<IEngine, Engine>();
         return services;
@@ -61,7 +57,6 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddOctaneEngine(this IServiceCollection services, IConfiguration configuration)
     {
         services.Configure<OctaneConfiguration>(configuration.GetSection("Octane"));
-        services.AddProgressBar();
         services.AddClient();
         services.AddTransient<IEngine, Engine>();
         return services;
@@ -73,7 +68,6 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddOctaneEngine(this IServiceCollection services, Action<OctaneConfiguration> configure)
     {
         services.Configure<OctaneConfiguration>(configure);
-        services.AddProgressBar();
         services.AddClient();
         services.AddTransient<IEngine, Engine>();
         return services;
@@ -85,7 +79,6 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddOctaneEngine(this IServiceCollection services, OctaneConfiguration configuration)
     {
         services.AddSingleton<IOptions<OctaneConfiguration>>(Options.Create(configuration));
-        services.AddProgressBar();
         services.AddClient();
         services.AddTransient<IEngine, Engine>();
         return services;

--- a/src/OctaneEngine/ShellProgressBar/ChildProgressBar.cs
+++ b/src/OctaneEngine/ShellProgressBar/ChildProgressBar.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace OctaneEngineCore.ShellProgressBar
 {
 	[ExcludeFromCodeCoverage]
-	public class ChildProgressBar : ProgressBarBase, IProgressBar
+	internal class ChildProgressBar : ProgressBarBase, IProgressBar
 	{
 		private readonly Action _scheduleDraw;
 		private readonly Action<string> _writeLine;

--- a/src/OctaneEngine/ShellProgressBar/ConsoleOutLine.cs
+++ b/src/OctaneEngine/ShellProgressBar/ConsoleOutLine.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace OctaneEngineCore.ShellProgressBar
 {
 	[ExcludeFromCodeCoverage]
-	public struct ConsoleOutLine
+	internal struct ConsoleOutLine
 	{
 		public bool Error { get; }
 		public string Line { get; }

--- a/src/OctaneEngine/ShellProgressBar/FixedDurationBar.cs
+++ b/src/OctaneEngine/ShellProgressBar/FixedDurationBar.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace OctaneEngineCore.ShellProgressBar
 {
 	[ExcludeFromCodeCoverage]
-	public class FixedDurationBar : ProgressBar
+	internal class FixedDurationBar : ProgressBar
 	{
 		public bool IsCompleted { get; private set; }
 

--- a/src/OctaneEngine/ShellProgressBar/IProgressBar.cs
+++ b/src/OctaneEngine/ShellProgressBar/IProgressBar.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace OctaneEngineCore.ShellProgressBar
 {
-	public interface IProgressBar : IDisposable
+	internal interface IProgressBar : IDisposable
 	{
 		ChildProgressBar Spawn(long maxTicks, string message, ProgressBarOptions options = null);
 

--- a/src/OctaneEngine/ShellProgressBar/IndeterminateChildProgressBar.cs
+++ b/src/OctaneEngine/ShellProgressBar/IndeterminateChildProgressBar.cs
@@ -5,7 +5,7 @@ using System.Threading;
 namespace OctaneEngineCore.ShellProgressBar
 {
 	[ExcludeFromCodeCoverage]
-	public class IndeterminateChildProgressBar : ChildProgressBar
+	internal class IndeterminateChildProgressBar : ChildProgressBar
 	{
 		private const int MaxTicksForIndeterminate = 20;
 		private Timer _timer;

--- a/src/OctaneEngine/ShellProgressBar/IndeterminateProgressBar.cs
+++ b/src/OctaneEngine/ShellProgressBar/IndeterminateProgressBar.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace OctaneEngineCore.ShellProgressBar
 {
 	[ExcludeFromCodeCoverage]
-	public class IndeterminateProgressBar : ProgressBar
+	internal class IndeterminateProgressBar : ProgressBar
 	{
 		private const int MaxTicksForIndeterminate = 20;
 

--- a/src/OctaneEngine/ShellProgressBar/ProgressBar.cs
+++ b/src/OctaneEngine/ShellProgressBar/ProgressBar.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -12,7 +12,7 @@ using ZLinq;
 namespace OctaneEngineCore.ShellProgressBar
 {
 	[ExcludeFromCodeCoverage]
-	public class ProgressBar : ProgressBarBase, IProgressBar
+	internal class ProgressBar : ProgressBarBase, IProgressBar
 	{
 		private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 

--- a/src/OctaneEngine/ShellProgressBar/ProgressBarBase.cs
+++ b/src/OctaneEngine/ShellProgressBar/ProgressBarBase.cs
@@ -7,7 +7,7 @@ using System.Threading;
 namespace OctaneEngineCore.ShellProgressBar
 {
 	[ExcludeFromCodeCoverage]
-	public abstract class ProgressBarBase
+	internal abstract class ProgressBarBase
 	{
 		static ProgressBarBase()
 		{

--- a/src/OctaneEngine/ShellProgressBar/ProgressBarHeight.cs
+++ b/src/OctaneEngine/ShellProgressBar/ProgressBarHeight.cs
@@ -1,6 +1,6 @@
 namespace OctaneEngineCore.ShellProgressBar
 {
-	public enum ProgressBarHeight
+	internal enum ProgressBarHeight
 	{
 		Increment, Decrement
 	}

--- a/src/OctaneEngine/ShellProgressBar/ProgressBarOptions.cs
+++ b/src/OctaneEngine/ShellProgressBar/ProgressBarOptions.cs
@@ -108,7 +108,7 @@ namespace OctaneEngineCore.ShellProgressBar
 		/// The delegate is expected to return the number of messages written to the console as a result of the string argument.
 		/// <para>Use case: pretty print or change the console colors, the progressbar will reset back</para>
 		/// </summary>
-		public Func<ConsoleOutLine, int> WriteQueuedMessage { get; set; }
+		internal Func<ConsoleOutLine, int> WriteQueuedMessage { get; set; }
 
 	}
 }

--- a/src/OctaneEngine/ShellProgressBar/ProgressModule.cs
+++ b/src/OctaneEngine/ShellProgressBar/ProgressModule.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 
 namespace OctaneEngineCore.ShellProgressBar;
 
-public static class ProgressModule
+internal static class ProgressModule
 {
     [ExcludeFromCodeCoverage]
     internal static void AddProgressBar(this IServiceCollection services)

--- a/src/OctaneEngine/ShellProgressBar/TaskbarProgress.cs
+++ b/src/OctaneEngine/ShellProgressBar/TaskbarProgress.cs
@@ -1,13 +1,13 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace OctaneEngineCore.ShellProgressBar
 {
 	[ExcludeFromCodeCoverage]
-	public static class TaskbarProgress
+	internal static class TaskbarProgress
 	{
-		public enum TaskbarStates
+		internal enum TaskbarStates
 		{
 			NoProgress = 0,
 			Indeterminate = 0x1,


### PR DESCRIPTION
Why it matters: Currently, core library classes Engine.cs and OctaneClient.cs have direct dependencies on console-specific ShellProgressBar.ProgressBar. This prevents using OctaneEngine in web applications, desktop UIs (WPF/MAUI), or headless background services without dragging in console UI rendering logic.

Refactoring Strategy: Remove references to ProgressBar from the core library. Instead, expose standard progress reporting using .NET's native IProgress<DownloadProgress> interface. The CLI app should subscribe to these updates and tick the progress bar independently.