### PR TITLE
Feature/throttle stream redesign

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="System.Buffers" Version="4.6.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.9" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.9" />
     <PackageVersion Include="ZLinq" Version="1.5.6" />
     <PackageVersion Include="ZString" Version="2.6.0" />
   </ItemGroup>

--- a/src/OctaneEngine/OctaneEngine.csproj
+++ b/src/OctaneEngine/OctaneEngine.csproj
@@ -63,6 +63,7 @@
         <PackageReference Include="System.Buffers" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="System.Text.Encoding.CodePages" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'" />
+        <PackageReference Include="System.Threading.RateLimiting" />
         <PackageReference Include="ZLinq" />
         <PackageReference Include="ZString" />
     </ItemGroup>

--- a/src/OctaneEngine/Streams/ThrottleStream.cs
+++ b/src/OctaneEngine/Streams/ThrottleStream.cs
@@ -87,11 +87,14 @@ public partial class ThrottleStream : Stream
             
             if (maxBytesPerSecond > 0)
             {
+                int tokensPerPeriod = Math.Max(1, maxBytesPerSecond / 10);
+                TimeSpan replenishmentPeriod = TimeSpan.FromSeconds((double)tokensPerPeriod / maxBytesPerSecond);
+
                 _snapshot = new LimiterSnapshot(maxBytesPerSecond, new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
                 {
                     TokenLimit = maxBytesPerSecond,
-                    TokensPerPeriod = Math.Max(1, maxBytesPerSecond / 10),
-                    ReplenishmentPeriod = TimeSpan.FromMilliseconds(100),
+                    TokensPerPeriod = tokensPerPeriod,
+                    ReplenishmentPeriod = replenishmentPeriod,
                     AutoReplenishment = true,
                     QueueLimit = int.MaxValue,
                     QueueProcessingOrder = QueueProcessingOrder.OldestFirst

--- a/src/OctaneEngine/Streams/ThrottleStream.cs
+++ b/src/OctaneEngine/Streams/ThrottleStream.cs
@@ -32,10 +32,32 @@ namespace OctaneEngineCore.Streams;
 
 public partial class ThrottleStream : Stream
 {
+    private sealed class LimiterSnapshot
+    {
+        public int Bps { get; }
+        public TokenBucketRateLimiter? Limiter { get; }
+        private int _refCount = 1;
+
+        public LimiterSnapshot(int bps, TokenBucketRateLimiter? limiter)
+        {
+            Bps = bps;
+            Limiter = limiter;
+        }
+
+        public void AddRef() => Interlocked.Increment(ref _refCount);
+
+        public void Release()
+        {
+            if (Interlocked.Decrement(ref _refCount) == 0)
+            {
+                Limiter?.Dispose();
+            }
+        }
+    }
+
     private readonly ILogger<ThrottleStream> _log;
-    private int _maxBps;
     private Stream _parentStream;
-    private TokenBucketRateLimiter? _rateLimiter;
+    private LimiterSnapshot? _snapshot;
     private readonly object _limiterLock = new();
 
     public ThrottleStream(ILoggerFactory factory)
@@ -58,14 +80,14 @@ public partial class ThrottleStream : Stream
 
     public void SetBps(int maxBytesPerSecond)
     {
-        _maxBps = maxBytesPerSecond;
+        LimiterSnapshot? oldSnapshot;
         lock (_limiterLock)
         {
-            var oldLimiter = _rateLimiter;
+            oldSnapshot = _snapshot;
             
             if (maxBytesPerSecond > 0)
             {
-                _rateLimiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+                _snapshot = new LimiterSnapshot(maxBytesPerSecond, new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
                 {
                     TokenLimit = maxBytesPerSecond,
                     TokensPerPeriod = Math.Max(1, maxBytesPerSecond / 10),
@@ -73,15 +95,14 @@ public partial class ThrottleStream : Stream
                     AutoReplenishment = true,
                     QueueLimit = int.MaxValue,
                     QueueProcessingOrder = QueueProcessingOrder.OldestFirst
-                });
+                }));
             }
             else
             {
-                _rateLimiter = null;
+                _snapshot = null;
             }
-
-            oldLimiter?.Dispose();
         }
+        oldSnapshot?.Release();
     }
 
     public override bool CanRead => _parentStream.CanRead;
@@ -113,64 +134,106 @@ public partial class ThrottleStream : Stream
     public override int Read(byte[] buffer, int offset, int count)
     {
         LogThrottleStreamRead();
-        TokenBucketRateLimiter? limiter;
-        lock (_limiterLock) { limiter = _rateLimiter; }
-
-        int maxToRead = count;
-        if (limiter != null)
-            maxToRead = Math.Min(count, _maxBps);
-
-        var read = _parentStream.Read(buffer, offset, maxToRead);
-
-        if (limiter != null && read > 0)
+        LimiterSnapshot? snap;
+        lock (_limiterLock)
         {
-            using var lease = limiter.AcquireAsync(read).AsTask().GetAwaiter().GetResult();
+            snap = _snapshot;
+            snap?.AddRef();
         }
 
-        return read;
+        try
+        {
+            int maxToRead = count;
+            if (snap != null)
+                maxToRead = Math.Min(count, snap.Bps);
+
+            var read = _parentStream.Read(buffer, offset, maxToRead);
+
+            if (snap?.Limiter != null && read > 0)
+            {
+                using var lease = snap.Limiter.AcquireAsync(read).AsTask().GetAwaiter().GetResult();
+                if (!lease.IsAcquired) throw new InvalidOperationException("Rate limit lease was not acquired.");
+            }
+
+            return read;
+        }
+        finally
+        {
+            snap?.Release();
+        }
     }
 
     public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
         LogThrottleStreamRead();
-        TokenBucketRateLimiter? limiter;
-        lock (_limiterLock) { limiter = _rateLimiter; }
-
-        int maxToRead = count;
-        if (limiter != null)
-            maxToRead = Math.Min(count, _maxBps);
-
-        var read = await _parentStream.ReadAsync(buffer, offset, maxToRead, cancellationToken).ConfigureAwait(false);
-
-        if (limiter != null && read > 0)
+        LimiterSnapshot? snap;
+        lock (_limiterLock)
         {
-            using var lease = await limiter.AcquireAsync(read, cancellationToken).ConfigureAwait(false);
-            if (!lease.IsAcquired) cancellationToken.ThrowIfCancellationRequested();
+            snap = _snapshot;
+            snap?.AddRef();
         }
 
-        return read;
+        try
+        {
+            int maxToRead = count;
+            if (snap != null)
+                maxToRead = Math.Min(count, snap.Bps);
+
+            var read = await _parentStream.ReadAsync(buffer, offset, maxToRead, cancellationToken).ConfigureAwait(false);
+
+            if (snap?.Limiter != null && read > 0)
+            {
+                using var lease = await snap.Limiter.AcquireAsync(read, cancellationToken).ConfigureAwait(false);
+                if (!lease.IsAcquired)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    throw new InvalidOperationException("Rate limit lease was not acquired.");
+                }
+            }
+
+            return read;
+        }
+        finally
+        {
+            snap?.Release();
+        }
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP || NET5_0_OR_GREATER
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken token = default)
     {
         LogThrottleStreamRead();
-        TokenBucketRateLimiter? limiter;
-        lock (_limiterLock) { limiter = _rateLimiter; }
-
-        int maxToRead = buffer.Length;
-        if (limiter != null)
-            maxToRead = Math.Min(maxToRead, _maxBps);
-
-        var read = await _parentStream.ReadAsync(buffer[..maxToRead], token).ConfigureAwait(false);
-
-        if (limiter != null && read > 0)
+        LimiterSnapshot? snap;
+        lock (_limiterLock)
         {
-            using var lease = await limiter.AcquireAsync(read, token).ConfigureAwait(false);
-            if (!lease.IsAcquired) token.ThrowIfCancellationRequested();
+            snap = _snapshot;
+            snap?.AddRef();
         }
 
-        return read;
+        try
+        {
+            int maxToRead = buffer.Length;
+            if (snap != null)
+                maxToRead = Math.Min(maxToRead, snap.Bps);
+
+            var read = await _parentStream.ReadAsync(buffer[..maxToRead], token).ConfigureAwait(false);
+
+            if (snap?.Limiter != null && read > 0)
+            {
+                using var lease = await snap.Limiter.AcquireAsync(read, token).ConfigureAwait(false);
+                if (!lease.IsAcquired)
+                {
+                    token.ThrowIfCancellationRequested();
+                    throw new InvalidOperationException("Rate limit lease was not acquired.");
+                }
+            }
+
+            return read;
+        }
+        finally
+        {
+            snap?.Release();
+        }
     }
 #endif
 
@@ -181,20 +244,32 @@ public partial class ThrottleStream : Stream
 
         while (totalWritten < count)
         {
-            int toWrite = count - totalWritten;
-            TokenBucketRateLimiter? limiter;
-            lock (_limiterLock) { limiter = _rateLimiter; }
-
-            if (limiter != null)
-                toWrite = Math.Min(toWrite, _maxBps);
-
-            if (limiter != null)
+            LimiterSnapshot? snap;
+            lock (_limiterLock)
             {
-                using var lease = limiter.AcquireAsync(toWrite).AsTask().GetAwaiter().GetResult();
+                snap = _snapshot;
+                snap?.AddRef();
             }
 
-            _parentStream.Write(buffer, offset + totalWritten, toWrite);
-            totalWritten += toWrite;
+            try
+            {
+                int toWrite = count - totalWritten;
+                if (snap != null)
+                    toWrite = Math.Min(toWrite, snap.Bps);
+
+                if (snap?.Limiter != null)
+                {
+                    using var lease = snap.Limiter.AcquireAsync(toWrite).AsTask().GetAwaiter().GetResult();
+                    if (!lease.IsAcquired) throw new InvalidOperationException("Rate limit lease was not acquired.");
+                }
+
+                _parentStream.Write(buffer, offset + totalWritten, toWrite);
+                totalWritten += toWrite;
+            }
+            finally
+            {
+                snap?.Release();
+            }
         }
     }
 
@@ -205,21 +280,36 @@ public partial class ThrottleStream : Stream
 
         while (totalWritten < count)
         {
-            int toWrite = count - totalWritten;
-            TokenBucketRateLimiter? limiter;
-            lock (_limiterLock) { limiter = _rateLimiter; }
-
-            if (limiter != null)
-                toWrite = Math.Min(toWrite, _maxBps);
-
-            if (limiter != null)
+            LimiterSnapshot? snap;
+            lock (_limiterLock)
             {
-                using var lease = await limiter.AcquireAsync(toWrite, cancellationToken).ConfigureAwait(false);
-                if (!lease.IsAcquired) cancellationToken.ThrowIfCancellationRequested();
+                snap = _snapshot;
+                snap?.AddRef();
             }
 
-            await _parentStream.WriteAsync(buffer, offset + totalWritten, toWrite, cancellationToken).ConfigureAwait(false);
-            totalWritten += toWrite;
+            try
+            {
+                int toWrite = count - totalWritten;
+                if (snap != null)
+                    toWrite = Math.Min(toWrite, snap.Bps);
+
+                if (snap?.Limiter != null)
+                {
+                    using var lease = await snap.Limiter.AcquireAsync(toWrite, cancellationToken).ConfigureAwait(false);
+                    if (!lease.IsAcquired)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        throw new InvalidOperationException("Rate limit lease was not acquired.");
+                    }
+                }
+
+                await _parentStream.WriteAsync(buffer, offset + totalWritten, toWrite, cancellationToken).ConfigureAwait(false);
+                totalWritten += toWrite;
+            }
+            finally
+            {
+                snap?.Release();
+            }
         }
     }
 
@@ -232,21 +322,36 @@ public partial class ThrottleStream : Stream
 
         while (totalWritten < count)
         {
-            int toWrite = count - totalWritten;
-            TokenBucketRateLimiter? limiter;
-            lock (_limiterLock) { limiter = _rateLimiter; }
-
-            if (limiter != null)
-                toWrite = Math.Min(toWrite, _maxBps);
-
-            if (limiter != null)
+            LimiterSnapshot? snap;
+            lock (_limiterLock)
             {
-                using var lease = await limiter.AcquireAsync(toWrite, token).ConfigureAwait(false);
-                if (!lease.IsAcquired) token.ThrowIfCancellationRequested();
+                snap = _snapshot;
+                snap?.AddRef();
             }
 
-            await _parentStream.WriteAsync(buffer.Slice(totalWritten, toWrite), token).ConfigureAwait(false);
-            totalWritten += toWrite;
+            try
+            {
+                int toWrite = count - totalWritten;
+                if (snap != null)
+                    toWrite = Math.Min(toWrite, snap.Bps);
+
+                if (snap?.Limiter != null)
+                {
+                    using var lease = await snap.Limiter.AcquireAsync(toWrite, token).ConfigureAwait(false);
+                    if (!lease.IsAcquired)
+                    {
+                        token.ThrowIfCancellationRequested();
+                        throw new InvalidOperationException("Rate limit lease was not acquired.");
+                    }
+                }
+
+                await _parentStream.WriteAsync(buffer.Slice(totalWritten, toWrite), token).ConfigureAwait(false);
+                totalWritten += toWrite;
+            }
+            finally
+            {
+                snap?.Release();
+            }
         }
     }
 #endif
@@ -256,10 +361,13 @@ public partial class ThrottleStream : Stream
         if (disposing)
         {
             _parentStream?.Dispose();
+            LimiterSnapshot? oldSnap;
             lock (_limiterLock)
             {
-                _rateLimiter?.Dispose();
+                oldSnap = _snapshot;
+                _snapshot = null;
             }
+            oldSnap?.Release();
         }
 
         base.Dispose(disposing);
@@ -272,10 +380,13 @@ public partial class ThrottleStream : Stream
         {
             await _parentStream.DisposeAsync().ConfigureAwait(false);
         }
+        LimiterSnapshot? oldSnap;
         lock (_limiterLock)
         {
-            _rateLimiter?.Dispose();
+            oldSnap = _snapshot;
+            _snapshot = null;
         }
+        oldSnap?.Release();
     }
 #endif
 

--- a/src/OctaneEngine/Streams/ThrottleStream.cs
+++ b/src/OctaneEngine/Streams/ThrottleStream.cs
@@ -23,8 +23,8 @@
 
 using System;
 using System.IO;
-using System.Reactive.Concurrency;
 using System.Threading;
+using System.Threading.RateLimiting;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -32,45 +32,56 @@ namespace OctaneEngineCore.Streams;
 
 public partial class ThrottleStream : Stream
 {
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _parentStream?.Dispose();
-        }
-
-        base.Dispose(disposing);
-    }
-
-    ~ThrottleStream()
-    {
-        Dispose(false);
-    }
-
     private readonly ILogger<ThrottleStream> _log;
     private int _maxBps;
     private Stream _parentStream;
-    private readonly IScheduler _scheduler;
-    private readonly IStopwatch _stopwatch;
-
-    private long _processed;
+    private TokenBucketRateLimiter? _rateLimiter;
+    private readonly object _limiterLock = new();
 
     public ThrottleStream(ILoggerFactory factory)
     {
-        _scheduler = Scheduler.Immediate;
         _log = factory.CreateLogger<ThrottleStream>();
-        _stopwatch = _scheduler.StartStopwatch();
-        _processed = 0;
+        // No throttling by default
     }
     
     public ThrottleStream(Stream parent, int maxBytesPerSecond, ILoggerFactory factory)
     {
-        _maxBps = maxBytesPerSecond;
         _parentStream = parent;
-        _scheduler = Scheduler.Immediate;
         _log = factory.CreateLogger<ThrottleStream>();
-        _stopwatch = _scheduler.StartStopwatch();
-        _processed = 0;
+        SetBps(maxBytesPerSecond);
+    }
+
+    public void SetStreamParent(Stream stream)
+    {
+        _parentStream = stream;
+    }
+
+    public void SetBps(int maxBytesPerSecond)
+    {
+        _maxBps = maxBytesPerSecond;
+        lock (_limiterLock)
+        {
+            var oldLimiter = _rateLimiter;
+            
+            if (maxBytesPerSecond > 0)
+            {
+                _rateLimiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = maxBytesPerSecond,
+                    TokensPerPeriod = Math.Max(1, maxBytesPerSecond / 10),
+                    ReplenishmentPeriod = TimeSpan.FromMilliseconds(100),
+                    AutoReplenishment = true,
+                    QueueLimit = int.MaxValue,
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+                });
+            }
+            else
+            {
+                _rateLimiter = null;
+            }
+
+            oldLimiter?.Dispose();
+        }
     }
 
     public override bool CanRead => _parentStream.CanRead;
@@ -82,53 +93,6 @@ public partial class ThrottleStream : Stream
     {
         get => _parentStream.Position;
         set => _parentStream.Position = value;
-    }
-
-    protected void Throttle(int bytes)
-    {
-        if (_maxBps <= 0 || bytes <= 0) return;
-
-        _processed += bytes;
-       
-        LogThrottleStreamProcessedProcessedBytes(_processed);
-        var targetTime = TimeSpan.FromSeconds((double)_processed / _maxBps);
-        var actualTime = _stopwatch.Elapsed;
-        var sleep = targetTime - actualTime;
-        if (sleep > TimeSpan.Zero)
-        {
-            using var waitHandle = new AutoResetEvent(false);
-            _scheduler.Sleep(sleep).GetAwaiter().OnCompleted(() => waitHandle.Set());
-            waitHandle.WaitOne();
-        }
-    }
-
-    private async Task ThrottleAsync(int bytes, CancellationToken cancellationToken)
-    {
-        if (_maxBps <= 0 || bytes <= 0) return;
-
-        _processed += bytes;
-        LogThrottleStreamProcessedProcessedBytes(_processed);
-
-        var targetTime = TimeSpan.FromSeconds((double)_processed / _maxBps);
-        var actualTime = _stopwatch.Elapsed;
-        var sleep = targetTime - actualTime;
-
-        if (sleep > TimeSpan.Zero)
-        {
-            if (_scheduler == Scheduler.Immediate)
-            {
-                await Task.Delay(sleep, cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                using (cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken)))
-                {
-                    _scheduler.Sleep(sleep).GetAwaiter().OnCompleted(() => tcs.TrySetResult(true));
-                    await tcs.Task.ConfigureAwait(false);
-                }
-            }
-        }
     }
 
     public override void Flush()
@@ -149,16 +113,41 @@ public partial class ThrottleStream : Stream
     public override int Read(byte[] buffer, int offset, int count)
     {
         LogThrottleStreamRead();
-        var read = _parentStream.Read(buffer, offset, count);
-        Throttle(read);
+        TokenBucketRateLimiter? limiter;
+        lock (_limiterLock) { limiter = _rateLimiter; }
+
+        int maxToRead = count;
+        if (limiter != null)
+            maxToRead = Math.Min(count, _maxBps);
+
+        var read = _parentStream.Read(buffer, offset, maxToRead);
+
+        if (limiter != null && read > 0)
+        {
+            using var lease = limiter.AcquireAsync(read).AsTask().GetAwaiter().GetResult();
+        }
+
         return read;
     }
 
     public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
         LogThrottleStreamRead();
-        var read = await _parentStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
-        await ThrottleAsync(read, cancellationToken).ConfigureAwait(false);
+        TokenBucketRateLimiter? limiter;
+        lock (_limiterLock) { limiter = _rateLimiter; }
+
+        int maxToRead = count;
+        if (limiter != null)
+            maxToRead = Math.Min(count, _maxBps);
+
+        var read = await _parentStream.ReadAsync(buffer, offset, maxToRead, cancellationToken).ConfigureAwait(false);
+
+        if (limiter != null && read > 0)
+        {
+            using var lease = await limiter.AcquireAsync(read, cancellationToken).ConfigureAwait(false);
+            if (!lease.IsAcquired) cancellationToken.ThrowIfCancellationRequested();
+        }
+
         return read;
     }
 
@@ -166,8 +155,21 @@ public partial class ThrottleStream : Stream
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken token = default)
     {
         LogThrottleStreamRead();
-        var read = await _parentStream.ReadAsync(buffer, token).ConfigureAwait(false);
-        await ThrottleAsync(read, token).ConfigureAwait(false);
+        TokenBucketRateLimiter? limiter;
+        lock (_limiterLock) { limiter = _rateLimiter; }
+
+        int maxToRead = buffer.Length;
+        if (limiter != null)
+            maxToRead = Math.Min(maxToRead, _maxBps);
+
+        var read = await _parentStream.ReadAsync(buffer[..maxToRead], token).ConfigureAwait(false);
+
+        if (limiter != null && read > 0)
+        {
+            using var lease = await limiter.AcquireAsync(read, token).ConfigureAwait(false);
+            if (!lease.IsAcquired) token.ThrowIfCancellationRequested();
+        }
+
         return read;
     }
 #endif
@@ -175,25 +177,93 @@ public partial class ThrottleStream : Stream
     public override void Write(byte[] buffer, int offset, int count)
     {
         LogThrottleStreamWrite();
-        _parentStream.Write(buffer, offset, count);
-        Throttle(count);
+        int totalWritten = 0;
+
+        while (totalWritten < count)
+        {
+            int toWrite = count - totalWritten;
+            TokenBucketRateLimiter? limiter;
+            lock (_limiterLock) { limiter = _rateLimiter; }
+
+            if (limiter != null)
+                toWrite = Math.Min(toWrite, _maxBps);
+
+            if (limiter != null)
+            {
+                using var lease = limiter.AcquireAsync(toWrite).AsTask().GetAwaiter().GetResult();
+            }
+
+            _parentStream.Write(buffer, offset + totalWritten, toWrite);
+            totalWritten += toWrite;
+        }
     }
 
     public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
         LogThrottleStreamWrite();
-        await _parentStream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
-        await ThrottleAsync(count, cancellationToken).ConfigureAwait(false);
+        int totalWritten = 0;
+
+        while (totalWritten < count)
+        {
+            int toWrite = count - totalWritten;
+            TokenBucketRateLimiter? limiter;
+            lock (_limiterLock) { limiter = _rateLimiter; }
+
+            if (limiter != null)
+                toWrite = Math.Min(toWrite, _maxBps);
+
+            if (limiter != null)
+            {
+                using var lease = await limiter.AcquireAsync(toWrite, cancellationToken).ConfigureAwait(false);
+                if (!lease.IsAcquired) cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            await _parentStream.WriteAsync(buffer, offset + totalWritten, toWrite, cancellationToken).ConfigureAwait(false);
+            totalWritten += toWrite;
+        }
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP || NET5_0_OR_GREATER
     public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken token = default)
     {
         LogThrottleStreamWrite();
-        await _parentStream.WriteAsync(buffer, token).ConfigureAwait(false);
-        await ThrottleAsync(buffer.Length, token).ConfigureAwait(false);
+        int totalWritten = 0;
+        int count = buffer.Length;
+
+        while (totalWritten < count)
+        {
+            int toWrite = count - totalWritten;
+            TokenBucketRateLimiter? limiter;
+            lock (_limiterLock) { limiter = _rateLimiter; }
+
+            if (limiter != null)
+                toWrite = Math.Min(toWrite, _maxBps);
+
+            if (limiter != null)
+            {
+                using var lease = await limiter.AcquireAsync(toWrite, token).ConfigureAwait(false);
+                if (!lease.IsAcquired) token.ThrowIfCancellationRequested();
+            }
+
+            await _parentStream.WriteAsync(buffer.Slice(totalWritten, toWrite), token).ConfigureAwait(false);
+            totalWritten += toWrite;
+        }
     }
 #endif
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _parentStream?.Dispose();
+            lock (_limiterLock)
+            {
+                _rateLimiter?.Dispose();
+            }
+        }
+
+        base.Dispose(disposing);
+    }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP || NET5_0_OR_GREATER
     public override async ValueTask DisposeAsync()
@@ -202,21 +272,12 @@ public partial class ThrottleStream : Stream
         {
             await _parentStream.DisposeAsync().ConfigureAwait(false);
         }
+        lock (_limiterLock)
+        {
+            _rateLimiter?.Dispose();
+        }
     }
 #endif
-    
-    public void SetStreamParent(Stream stream)
-    {
-        _parentStream = stream;
-    }
-
-    public void SetBps(int maxBytesPerSecond)
-    {
-        _maxBps = maxBytesPerSecond;
-    }
-
-    [LoggerMessage(LogLevel.Trace, "Throttle stream processed {processed} bytes")]
-    partial void LogThrottleStreamProcessedProcessedBytes(long processed);
 
     [LoggerMessage(LogLevel.Trace, "Throttle stream read")]
     partial void LogThrottleStreamRead();

--- a/tests/OctaneTestProject/ThrottleStreamTest.cs
+++ b/tests/OctaneTestProject/ThrottleStreamTest.cs
@@ -90,7 +90,7 @@ namespace OctaneTestProject
             var buffer = new byte[1000]; // Would take 10 seconds to write
             using var cts = new CancellationTokenSource(200); // Cancel after 200ms
             
-            Assert.CatchAsync<OperationCanceledException>((Func<Task>)(async () =>
+            Assert.CatchAsync<OperationCanceledException>((AsyncTestDelegate)(async () =>
             {
                 await ts.WriteAsync(buffer, 0, buffer.Length, cts.Token);
             }));
@@ -138,7 +138,7 @@ namespace OctaneTestProject
             var ms = new MemoryStream();
             var ts = new ThrottleStream(ms, 1024, _factory);
             await ts.DisposeAsync();
-            Assert.Throws<ObjectDisposedException>((TestDelegate)(() => ms.WriteByte(1)));
+            Assert.Throws<ObjectDisposedException>((Action)(() => ms.WriteByte(1)));
         }
 
         [Test]
@@ -147,7 +147,7 @@ namespace OctaneTestProject
             var ms = new MemoryStream();
             var ts = new ThrottleStream(ms, 1024, _factory);
             ts.Dispose();
-            Assert.Throws<ObjectDisposedException>((TestDelegate)(() => ms.WriteByte(1)));
+            Assert.Throws<ObjectDisposedException>((Action)(() => ms.WriteByte(1)));
         }
     }
 }

--- a/tests/OctaneTestProject/ThrottleStreamTest.cs
+++ b/tests/OctaneTestProject/ThrottleStreamTest.cs
@@ -63,15 +63,44 @@ namespace OctaneTestProject
             using var ms = new MemoryStream();
             var ts = new ThrottleStream(ms, 1024, _factory);
             ts.SetBps(2048);
-            // No direct way to check, but should not throw
             Assert.Pass();
+        }
+
+        [Test]
+        public async Task ReadAsync_LargeBuffer_ShouldLimitToTokenBurstSize()
+        {
+            // Token bucket strictly limits burst to TokenLimit (which is maxBps).
+            // A request for 2000 bytes should short-read up to 500 bytes.
+            var data = new byte[2000];
+            using var ms = new MemoryStream(data);
+            var ts = new ThrottleStream(ms, 500, _factory);
+            
+            var buffer = new byte[2000];
+            var bytesRead = await ts.ReadAsync(buffer, 0, buffer.Length);
+            
+            Assert.That(bytesRead, Is.EqualTo(500));
+        }
+
+        [Test]
+        public async Task WriteAsync_LargeBuffer_ShouldCancelProperlyWhenThrottled()
+        {
+            using var ms = new MemoryStream();
+            var ts = new ThrottleStream(ms, 100, _factory); // 100 bps
+            
+            var buffer = new byte[1000]; // Would take 10 seconds to write
+            using var cts = new CancellationTokenSource(200); // Cancel after 200ms
+            
+            Assert.CatchAsync<OperationCanceledException>((Func<Task>)(async () =>
+            {
+                await ts.WriteAsync(buffer, 0, buffer.Length, cts.Token);
+            }));
         }
 
         [Test]
         public void WriteAndRead_ShouldThrottleAndWorkCorrectly()
         {
             using var ms = new MemoryStream();
-            var ts = new ThrottleStream(ms, 1024 * 1024, _factory); // High BPS to avoid actual throttling delay
+            var ts = new ThrottleStream(ms, 1024 * 1024, _factory); // High BPS
             var data = new byte[] {1, 2, 3, 4, 5};
             ts.Write(data, 0, data.Length);
             ts.Flush();
@@ -109,8 +138,7 @@ namespace OctaneTestProject
             var ms = new MemoryStream();
             var ts = new ThrottleStream(ms, 1024, _factory);
             await ts.DisposeAsync();
-            Action testDelegate = () => ms.WriteByte(1);
-            Assert.Throws<ObjectDisposedException>(testDelegate);
+            Assert.Throws<ObjectDisposedException>((TestDelegate)(() => ms.WriteByte(1)));
         }
 
         [Test]
@@ -119,8 +147,7 @@ namespace OctaneTestProject
             var ms = new MemoryStream();
             var ts = new ThrottleStream(ms, 1024, _factory);
             ts.Dispose();
-            Action testDelegate = () => ms.WriteByte(1);
-            Assert.Throws<ObjectDisposedException>(testDelegate);
+            Assert.Throws<ObjectDisposedException>((TestDelegate)(() => ms.WriteByte(1)));
         }
     }
-} 
+}


### PR DESCRIPTION
Improve the throttle stream implementation using rate limiting instead of manual throttling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded stream throttling to a token-bucket rate limiter for both reads and writes, including burst-cap behavior for large buffers.
  * Writes are now throttled in smaller chunks for smoother, more consistent bandwidth limiting.
* **Bug Fixes**
  * Improved cancellation handling for throttled `WriteAsync` operations.
  * Strengthened throttling and disposal so the underlying stream is reliably released.
* **Tests**
  * Added async coverage for large-buffer read limits, cancellation during throttled writes, and disposal behavior.
* **Chores**
  * Added/centralized the required rate-limiting NuGet dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->