### PR TITLE
⚡ Bolt: optimize PauseToken fast-path and async await continuations in download loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-05-16 — [Allocation-Free Rendering with ZLinq]
 **Learning:** High-frequency UI rendering (like a CLI progress bar) should avoid standard LINQ operations (.Where, .Select, .ToList) and anonymous objects to minimize GC pressure. While manual loops are effective, libraries like `ZLinq` provide allocation-free LINQ-like extensions using value-typed enumerators, allowing for both readability and performance.
 **Action:** Use `ZLinq` or manual loops to avoid heap allocations in hot paths like render ticks.
+
+## 2025-05-17 — [Hot-Path Pause Checks and ConfigureAwait]
+**Learning:** In high-throughput streaming loops where pause tokens are checked on every buffer read/write, delegating or instantiating task objects when unpaused adds allocation and call stack overhead. Early-exiting on `!_tokenSource.IsPaused` avoids Task creation and volatile state checks. Additionally, missing `.ConfigureAwait(false)` on hot stream operations causes unnecessary context synchronization across thread pool continuations.
+**Action:** Always short-circuit unpaused `PauseToken` checks and ensure `.ConfigureAwait(false)` is used on every await statement in library streaming pipelines.

--- a/src/OctaneEngine/Clients/DefaultClient.cs
+++ b/src/OctaneEngine/Clients/DefaultClient.cs
@@ -80,13 +80,13 @@ public class DefaultClient : IClient
         PauseToken pauseToken,
         CancellationToken cancellationToken)
     {
-        using var contentStream = await message.Content.ReadAsStreamAsync();
+        using var contentStream = await message.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
         var pipe = new Pipe(_pipeOptions);
         var fillTask = FillPipeAsync(contentStream, pipe.Writer, pauseToken, cancellationToken);
         var readTask = ReadPipeAsync(pipe.Reader, stream, progress, pauseToken, cancellationToken);
         
-        await Task.WhenAll(fillTask, readTask);
+        await Task.WhenAll(fillTask, readTask).ConfigureAwait(false);
     }
 
     private async Task FillPipeAsync(Stream source, PipeWriter writer, PauseToken pauseToken, CancellationToken cancellationToken)
@@ -96,7 +96,7 @@ public class DefaultClient : IClient
         while (true)
         {
             Memory<byte> memory = writer.GetMemory(bufferSize);
-            int bytesRead = await source.ReadAsync(memory, cancellationToken);
+            int bytesRead = await source.ReadAsync(memory, cancellationToken).ConfigureAwait(false);
             await pauseToken.WaitWhilePausedAsync(cancellationToken).ConfigureAwait(false);
 
             if (bytesRead == 0)
@@ -106,7 +106,7 @@ public class DefaultClient : IClient
             
             writer.Advance(bytesRead);
             
-            FlushResult flushResult = await writer.FlushAsync();
+            FlushResult flushResult = await writer.FlushAsync().ConfigureAwait(false);
             if (flushResult.IsCompleted)
             {
                 break;
@@ -120,13 +120,13 @@ public class DefaultClient : IClient
 
         while (true)
         {
-            ReadResult result = await reader.ReadAsync(cancellationToken);
+            ReadResult result = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
             await pauseToken.WaitWhilePausedAsync(cancellationToken).ConfigureAwait(false);
             ReadOnlySequence<byte> buffer = result.Buffer;
 
             foreach (var segment in buffer)
             {
-                await destination.WriteAsync(segment);
+                await destination.WriteAsync(segment).ConfigureAwait(false);
                 totalBytesWritten += segment.Length;
             }
             
@@ -171,7 +171,7 @@ public class DefaultClient : IClient
             }
         });
         using var stream = _mmf.CreateViewStream();
-        await CopyMessageContentToStreamWithProgressAsync(message, stream, progress, pauseToken, cancellationToken);
+        await CopyMessageContentToStreamWithProgressAsync(message, stream, progress, pauseToken, cancellationToken).ConfigureAwait(false);
     }
 
     public void Dispose()

--- a/src/OctaneEngine/Clients/OctaneClient.cs
+++ b/src/OctaneEngine/Clients/OctaneClient.cs
@@ -197,14 +197,14 @@ public partial class OctaneClient : IClient
 
             while (true)
             {
-                var bytesRead = await wrappedStream.ReadAsync(readBuffer.AsMemory(), cancellationToken);
+                var bytesRead = await wrappedStream.ReadAsync(readBuffer.AsMemory(), cancellationToken).ConfigureAwait(false);
                 await pauseToken.WaitWhilePausedAsync(cancellationToken).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
                     break;
                 }
 
-                await stream.WriteAsync(readBuffer.AsMemory(0, bytesRead), cancellationToken);
+                await stream.WriteAsync(readBuffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
                 bytesReadOverall += bytesRead;
                         
                 if(child != null && (bytesReadOverall - lastProgressUpdate >= progressUpdateInterval))
@@ -216,8 +216,8 @@ public partial class OctaneClient : IClient
         }
         finally
         {
-            await stream.DisposeAsync();
-            await wrappedStream.DisposeAsync();
+            await stream.DisposeAsync().ConfigureAwait(false);
+            await wrappedStream.DisposeAsync().ConfigureAwait(false);
             _memPool.Return(readBuffer);
             LogBufferReturnedToMemoryPool();
         }
@@ -250,7 +250,7 @@ public partial class OctaneClient : IClient
                 var pipe = new Pipe(_pipeOptions);
                 var writing = FillPipeAsync(wrappedStream, pipe.Writer, cancellationToken, pauseToken);
                 var reading = ReadPipeToFileAsync(pipe.Reader, piece, child, accessorPtr, cancellationToken, pauseToken);
-                await Task.WhenAll(reading, writing);
+                await Task.WhenAll(reading, writing).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -267,7 +267,7 @@ public partial class OctaneClient : IClient
                 accessor.SafeMemoryMappedViewHandle.ReleasePointer();
             }
 
-            await wrappedStream.DisposeAsync();
+            await wrappedStream.DisposeAsync().ConfigureAwait(false);
         }
     }
 
@@ -280,7 +280,7 @@ public partial class OctaneClient : IClient
             while (true)
             {
                 var memory = writer.GetMemory(bufferSize);
-                var bytesRead = await stream.ReadAsync(memory, token);
+                var bytesRead = await stream.ReadAsync(memory, token).ConfigureAwait(false);
                 await pauseToken.WaitWhilePausedAsync(token).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
@@ -288,7 +288,7 @@ public partial class OctaneClient : IClient
                 } // End of stream 
 
                 writer.Advance(bytesRead);
-                var result = await writer.FlushAsync(token);
+                var result = await writer.FlushAsync(token).ConfigureAwait(false);
                 if (result.IsCompleted || result.IsCanceled)
                 {
                     break;
@@ -297,7 +297,7 @@ public partial class OctaneClient : IClient
         }
         finally
         {
-            await writer.CompleteAsync();
+            await writer.CompleteAsync().ConfigureAwait(false);
         }
     }
     
@@ -313,7 +313,7 @@ public partial class OctaneClient : IClient
             while (true)
             {
                 if (!reader.TryRead(out ReadResult result))
-                    result = await reader.ReadAsync(token);
+                    result = await reader.ReadAsync(token).ConfigureAwait(false);
 
                 await pauseToken.WaitWhilePausedAsync(token).ConfigureAwait(false);
 
@@ -397,7 +397,7 @@ public partial class OctaneClient : IClient
         }
         finally
         {
-            await reader.CompleteAsync();
+            await reader.CompleteAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/OctaneEngine/Implementations/Engine.cs
+++ b/src/OctaneEngine/Implementations/Engine.cs
@@ -152,7 +152,7 @@ public partial class Engine: IEngine, IDisposable
     {
         var client = _clientFactory.CreateClient("OctaneClient");
         using var request = new HttpRequestMessage(HttpMethod.Head, url);
-        var response = await client.SendAsync(request);
+        var response = await client.SendAsync(request).ConfigureAwait(false);
         var responseLength = response.Content.Headers.ContentLength ?? 0;
         var rangeSupported = response.Headers.AcceptRanges.Contains("bytes");
         LogRangeSupportedRange(rangeSupported);
@@ -208,7 +208,7 @@ public partial class Engine: IEngine, IDisposable
             var octaneClient = _client ?? new OctaneClient(_config, client, _factory);
             var defaultClient = _defaultClient ?? new DefaultClient(client, _config);
 
-            (var length, clientType) = await getFileSizeAndRangeSupport(request.Url);
+            (var length, clientType) = await getFileSizeAndRangeSupport(request.Url).ConfigureAwait(false);
             
             #region Varible Initilization
             filename = request.OutFile ?? Path.GetFileName(new Uri(request.Url).LocalPath);

--- a/src/OctaneEngine/PauseToken.cs
+++ b/src/OctaneEngine/PauseToken.cs
@@ -41,7 +41,10 @@ public readonly struct PauseToken
 
     public Task WaitWhilePausedAsync(CancellationToken token = default)
     {
-        var task = _tokenSource?.WaitWhilePausedAsync();
+        if (_tokenSource == null || !_tokenSource.IsPaused)
+            return Task.CompletedTask;
+
+        var task = _tokenSource.WaitWhilePausedAsync();
         
         // If there's no source, or the source returned a completed task (i.e. not paused)
         if (task == null || task.IsCompleted)


### PR DESCRIPTION
Optimized PauseToken.WaitWhilePausedAsync fast-path to short-circuit and return Task.CompletedTask immediately when not paused. Added .ConfigureAwait(false) to all un-configured await calls in hot download loops within OctaneClient, DefaultClient, and Engine.

---
*PR created automatically by Jules for task [15163909202409448960](https://jules.google.com/task/15163909202409448960) started by @gregyjames*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved responsiveness and efficiency for asynchronous downloads, streaming, piping, and resource cleanup.
  * Reduced unnecessary waiting when operations are not paused, especially along frequently used execution paths.
  * Improved asynchronous processing in environments with synchronization contexts.

* **Compatibility**
  * No changes to public APIs or user-facing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->