### PR TITLE
⚡ Bolt: Use synchronous write for MemoryMappedViewStream in download loops

### DIFF
--- a/src/OctaneEngine/Clients/DefaultClient.cs
+++ b/src/OctaneEngine/Clients/DefaultClient.cs
@@ -126,7 +126,21 @@ public class DefaultClient : IClient
 
             foreach (var segment in buffer)
             {
-                await destination.WriteAsync(segment).ConfigureAwait(false);
+                // Writing to MemoryMappedViewStream is a synchronous memory copy operation into mapped view;
+                // using synchronous stream.Write eliminates ValueTask/Task allocations and state machine overhead.
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP || NET5_0_OR_GREATER
+                destination.Write(segment.Span);
+#else
+                if (System.Runtime.InteropServices.MemoryMarshal.TryGetArray(segment, out var arraySegment))
+                {
+                    destination.Write(arraySegment.Array!, arraySegment.Offset, arraySegment.Count);
+                }
+                else
+                {
+                    var array = segment.ToArray();
+                    destination.Write(array, 0, array.Length);
+                }
+#endif
                 totalBytesWritten += segment.Length;
             }
             

--- a/src/OctaneEngine/Clients/OctaneClient.cs
+++ b/src/OctaneEngine/Clients/OctaneClient.cs
@@ -204,7 +204,9 @@ public partial class OctaneClient : IClient
                     break;
                 }
 
-                await stream.WriteAsync(readBuffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+                // Writing to MemoryMappedViewStream is a synchronous memory copy operation into mapped view;
+                // using synchronous stream.Write eliminates ValueTask/Task allocations and state machine overhead.
+                stream.Write(readBuffer, 0, bytesRead);
                 bytesReadOverall += bytesRead;
                         
                 if(child != null && (bytesReadOverall - lastProgressUpdate >= progressUpdateInterval))


### PR DESCRIPTION
Eliminated ValueTask/Task state machine allocations and continuation overhead in hot download loops by using synchronous stream.Write on MemoryMappedViewStream in OctaneClient and DefaultClient.

---
*PR created automatically by Jules for task [3460866161443320329](https://jules.google.com/task/3460866161443320329) started by @gregyjames*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved download and data-transfer write handling for faster, more consistent streaming.
  * Preserved download progress reporting and completion behavior across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->